### PR TITLE
Fix: error when building, nullref when building

### DIFF
--- a/Editor/TestAssetBundler.cs
+++ b/Editor/TestAssetBundler.cs
@@ -41,7 +41,12 @@ public class TestAssetBundler : IPreprocessBuildWithReport {
         };
 
         foreach (var setName in sampleSetNames) {
-            var sampleSet = AssetDatabase.LoadAssetAtPath<SampleSet>( $"Packages/com.atteneder.gltf-tests/Runtime/SampleSets/{setName}.asset");
+            var samplePath = $"Packages/com.atteneder.gltf-test-framework/Runtime/SampleSets/{setName}.asset";
+            var sampleSet = AssetDatabase.LoadAssetAtPath<SampleSet>(samplePath);
+            if (!sampleSet) {
+                Debug.LogWarning($"Expected SampleSet at {samplePath} doesn't exist.");
+                continue;
+            }
             sampleSet.CreateJSON();
             sampleSet.CopyToStreamingAssets();
         }

--- a/Runtime/Scripts/Sample/SampleSet.cs
+++ b/Runtime/Scripts/Sample/SampleSet.cs
@@ -20,7 +20,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEditor.SceneManagement;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;


### PR DESCRIPTION
Editor using in runtime file, and sanitization if sample sets are missing